### PR TITLE
Return string from .dtf.h instead of int

### DIFF
--- a/libs/dtf.q
+++ b/libs/dtf.q
@@ -135,13 +135,13 @@ yy:{-2#yyyy@x}
 /# @function h To get Hours as 0-23 
 /#    @param x Date to be formatted   
 /#    @return Hours 
-h:{`hh$x}
+h:{string `hh$x}
 /# @code q).dtf.h 01:05:21
 
 /# @function hh To get Hours as 00-23 
 /#    @param x Date to be formatted   
 /#    @return Hours 
-hh:{"0"^-2$string h@x}
+hh:{"0"^-2$h@x}
 /# @code q).dtf.hh 01:05:21
 
 /# @function h1 To get Hours as 1-12 


### PR DESCRIPTION
.dtf.h currently returns an int, meaning any the return type of any .dft.format query with "h" is a general list. This modifies .dtf.h to return a string and .dtf.hh to work with this change